### PR TITLE
fix unrecognized platform-specific intrinsic function: simd_shuffle2 etc.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,20 +24,20 @@ simd = ["packed_simd"]
 [dependencies]
 
 [dependencies.packed_simd]
-package = "packed_simd_2"
-version = "0.3.4"
+package = "packed_simd"
+version = "0.3.9"
 features = ["into_bits"]
 optional = true
 
 [dependencies.afl]
-version = "0.5.2"
+version = "0.13.3"
 optional = true
 
 [dev-dependencies]
-quickcheck = "0.9.0"
-quickcheck_macros = "0.8.0"
-criterion = "0.3"
-rand = "0.7"
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
+criterion = "0.5"
+rand = "0.8"
 succinct = "0.5.2"
 
 [[bench]]


### PR DESCRIPTION
## This fixes the errors: "unrecognized platform-specific intrinsic function: simd_shuffle2" etc. 

Error reported in <https://github.com/sujayakar/rsdict/issues/7>. 
**The error only occurred with the newest nightly versions**

Update dependencies to their newest version.
Successfully tested with:

stable: 1.71.1 2023-08-03
nightly: 1.73.0 23-08-06

* `cargo +stable test`
* `cargo +nightly test`
* `cargo +nightly test --features packed_simd`
* `cargo +stable afl build --release --test rsdict_fuzz --features fuzz`
* `cargo +nightly afl build --release --test rsdict_fuzz --features fuzz`

The last two report:

```
warning: unused import: `succinct::rank::RankSupport`
warning: unused import: `succinct::select::SelectSupport`
```

However I didn't remove them in this PR as this occurs with the previous version as well.