### PR TITLE
refactor to standard library portable_simd feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,7 @@ debug = true
 [features]
 default = []
 fuzz = ["afl"]
-simd = ["packed_simd"]
-
-[dependencies]
-
-[dependencies.packed_simd]
-package = "packed_simd"
-version = "0.3.9"
-features = ["into_bits"]
-optional = true
+simd = []
 
 [dependencies.afl]
 version = "0.13.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@
 //! over as many small blocks as possible, and then select within a small
 //! block. As with rank, we're able to select within a small block directly.
 
+#![cfg_attr(feature = "simd", feature(portable_simd))]
+
 #[cfg(test)]
 extern crate quickcheck;
 #[cfg(test)]

--- a/src/rank_acceleration.rs
+++ b/src/rank_acceleration.rs
@@ -19,6 +19,7 @@ mod accelerated {
     use crate::enum_code::ENUM_CODE_LENGTH;
     use std::arch::x86_64::{__m128i, _mm_sad_epu8, _mm_setzero_si128};
     use std::simd::{num::SimdUint, u64x2, u8x16, Simd};
+    use std::simd::prelude::SimdOrd;
     use std::slice;
     use std::u64;
 
@@ -79,7 +80,7 @@ mod accelerated {
         //
         //    ENUM_CODE_LENGTH[i] == ENUM_CODE_LENGTH[f(i)] for i in [0, 64].
         //
-        let indices = classes.min(u8x16::splat(64) - classes).min(u8x16::splat(15));
+        let indices = classes.simd_min(u8x16::splat(64) - classes).simd_min(u8x16::splat(15));
         let enum_code_vector: u8x16 = u8x16::from([
             ENUM_CODE_LENGTH[0], ENUM_CODE_LENGTH[1], ENUM_CODE_LENGTH[2], ENUM_CODE_LENGTH[3],
             ENUM_CODE_LENGTH[4], ENUM_CODE_LENGTH[5], ENUM_CODE_LENGTH[6], ENUM_CODE_LENGTH[7],


### PR DESCRIPTION
As packed_simd no longer works with Rust nightly 1.78 (see <https://github.com/rust-lang/packed_simd/issues/359>), this PR tries to refactor to the nightly-only portable_simd feature.

**Warning** I am not a SIMD expert and while it builds, some tests still fail, however I cannot find the reason right now.
I also used transmute, so this should go through a thorough review.